### PR TITLE
added lodash-node and defaults merge

### DIFF
--- a/lib/rest-connector.js
+++ b/lib/rest-connector.js
@@ -2,6 +2,7 @@ var debug = require('debug')('loopback:connector:rest');
 var RestResource = require('./rest-model');
 var RequestBuilder = require('./rest-builder');
 var request = require('request');
+var _ = require('lodash');
 
 /**
  * Export the initialize method to loopback-datasource-juggler
@@ -94,37 +95,30 @@ exports.RestConnector = RestConnector;
  * @constructor
  */
 function RestConnector(baseURL, settings) {
+  settings = settings || {};
+  var options = settings.options || {},
+      defaults = settings.defaults || {};
+
   this._baseURL = baseURL;
   this._models = {};
   this._resources = {};
-  this._settings = settings || {};
 
-  // Extract the default options for request module
-  var options = this._settings.options ||
-    this._settings.defaults || this._settings;
+  debug('RestConnector:settings', settings);
 
-  var defaults = {};
+  settings = _.omit(settings, ['options', 'defaults', 'connector', 'operations']);
 
-  if (options) {
-    if (options.clientCert) {
-      defaults.cert = options.clientCert;
-    }
-    if (options.clientKey) {
-      defaults.key = options.clientKey;
-    }
+  // Cascade the options in priority order for request module
+  // options is the highest order then settings and defaults
+  this._settings = _.merge(defaults, settings, options);
 
-    // Pass in options to request
-    for (var p in options) {
-      if (p === 'connector' || p === 'operations') {
-        continue;
-      }
-      if (defaults[p] === undefined) {
-        defaults[p] = options[p];
-      }
-    }
+  // map clientCert/clientKey to cert/key for backward compatibility
+  if (this._settings.clientKey && this._settings.clientCert) {
+    this._settings.key = this._settings.clientKey;
+    this._settings.cert = this._settings.clientCert;
   }
 
-  this._request = request.defaults(defaults);
+  debug('RestConnector:this._settings', this._settings);
+  this._request = request.defaults(this._settings);
 }
 
 /**
@@ -400,6 +394,3 @@ RestConnector.prototype.updateAttributes = function (model, id, data, callback) 
 RestConnector.prototype.getTypes = function() {
   return ['rest'];
 };
-
-
-

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "./node_modules/.bin/mocha --timeout 30000 test/*test.js"
   },
   "dependencies": {
+    "lodash": "^3.2.0",
     "request": "^2.53.0",
     "qs": "^2.3.3",
     "mime": "^1.3.4",

--- a/test/rest-adapter-custom.test.js
+++ b/test/rest-adapter-custom.test.js
@@ -171,5 +171,56 @@ describe('REST connector', function () {
 
     });
 
+    it('should map clientKey and clientCert to key and cert for backwards compat', function () {
+      var spec = require('./request-template.json');
+      var template = {
+        clientKey : 'CLIENT.KEY',
+        clientCert: 'CLIENT.CERT',
+        operations: [
+          {template: spec, functions: {
+              m1: ["x"]
+          }}
+        ]
+      };
+      var ds = new DataSource(require('../lib/rest-connector'), template);
+      assert.equal(ds.connector._settings.key, template.clientKey);
+      assert.equal(ds.connector._settings.cert, template.clientCert);
+    });
+
+    it('should keep order of prececence: options, top level, and defaults', function (done) {
+      var spec = require('./request-template.json');
+      var template = {
+        options : {
+          'headers': {
+            'x-options'   : 'options'
+          }
+        },
+        'headers': {
+          'x-top'         : 'top',
+          'x-options'     : 'top'
+        },
+        defaults: {
+          'headers': {
+            'x-defaults'  : 'defaults',
+            'x-options'   : 'defaults',
+            'x-top'       : 'defaults'
+          }
+        },
+        operations: [
+          {template: spec, functions: {
+              m1: ["x"]
+          }}
+        ]
+      };
+      var ds = new DataSource(require('../lib/rest-connector'), template);
+      var model = ds.createModel('rest');
+      model.m1(3, function (err, result) {
+        assert.equal(result.headers['x-defaults'], 'defaults');
+        assert.equal(result.headers['x-options'], 'options');
+        assert.equal(result.headers['x-top'], 'top');
+        done(err, result);
+      });
+    });
+
   });
 });


### PR DESCRIPTION
This change does a merge of all options cascading from defaults, to the top level and finally the options objects.  I was unclear what the correct merge order should actually be so I went with what seemed the most logical however I'm not entirely clear what the options object should have in terms of order of precedence.  I tried to draw from your previous code that had an order of precedence but didn't merge the options in that order.  If you want that corrected I can easily make changes.

Not sure if you guys are ok with an the add of lodash-node to the package but it provides much better utility functions than trying to do this all myself.
I also created a utils module to export a deep merge function that ensures all options are copied over from right to left.

Happy Holidays.