### PR TITLE
add promise support for rest-builder invoke method

### DIFF
--- a/lib/rest-builder.js
+++ b/lib/rest-builder.js
@@ -10,6 +10,7 @@ var request = require('request');
 var path = require('path');
 var fs = require('fs');
 
+var utils = require('./utils');
 var JsonTemplate = require('./template');
 var RestResource = require('./rest-model');
 
@@ -456,8 +457,7 @@ RequestBuilder.prototype.operation = function (parameterNames) {
         parameters[params[i]] = arguments[i];
       }
     }
-    // console.log(parameters);
-    self.invoke(parameters, cb);
+    return self.invoke(parameters, cb);
   };
 
 };
@@ -471,6 +471,8 @@ RequestBuilder.prototype.invoke = function (parameters, cb) {
   if (!cb && typeof parameters === 'function') {
     cb = parameters;
     parameters = {};
+  } else if (!cb) {
+    cb = utils.createPromiseCallback();
   }
   parameters = parameters || {};
   var json = this.build(parameters);
@@ -560,6 +562,7 @@ RequestBuilder.prototype.invoke = function (parameters, cb) {
       form.append(a.field, fs.createReadStream(path.join(__dirname, a.path)), a);
     });
   }
+  return cb.promise;
 };
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,28 @@
+exports.createPromiseCallback = createPromiseCallback;
+
+function createPromiseCallback() {
+  var cb;
+
+  if (!global.Promise) {
+    cb = function(){};
+    cb.promise = {};
+    Object.defineProperty(cb.promise, 'then', { get: throwPromiseNotDefined });
+    Object.defineProperty(cb.promise, 'catch', { get: throwPromiseNotDefined });
+    return cb;
+  }
+
+  var promise = new Promise(function (resolve, reject) {
+    cb = function (err, data) {
+      if (err) return reject(err);
+      return resolve(data);
+    };
+  });
+  cb.promise = promise;
+  return cb;
+}
+
+function throwPromiseNotDefined() {
+  throw new Error(
+    'Your Node runtime does support ES6 Promises. ' +
+    'Set "global.Promise" to your preferred implementation of promises.');
+}

--- a/test/rest-builder.test.js
+++ b/test/rest-builder.test.js
@@ -209,8 +209,15 @@ describe('REST Request Builder', function () {
     it('should return a promise when no callback is specified', function(){
       var builder = new RequestBuilder(require('./request-template.json'));
       var promise = builder.invoke({p: 1, a: 100, b: false});
-      assert(promise.hasOwnProperty('then'));
-      assert(promise.hasOwnProperty('catch'));
+
+      try {
+        // without native promise support, this will throw an error
+        assert(typeof promise['then'] === "function");
+        assert(typeof promise['catch'] === "function");
+      } catch(err) {
+        assert(promise.hasOwnProperty('then'));
+        assert(promise.hasOwnProperty('catch'));
+      }
     });
   })
 });

--- a/test/rest-builder.test.js
+++ b/test/rest-builder.test.js
@@ -204,4 +204,13 @@ describe('REST Request Builder', function () {
     });
 
   });
+
+  describe('invoke', function(){
+    it('should return a promise when no callback is specified', function(){
+      var builder = new RequestBuilder(require('./request-template.json'));
+      var promise = builder.invoke({p: 1, a: 100, b: false});
+      assert(promise.hasOwnProperty('then'));
+      assert(promise.hasOwnProperty('catch'));
+    });
+  })
 });


### PR DESCRIPTION
I'm using the same `createPromiseCallback` utility function from [76ebdcb91](https://github.com/strongloop/loopback-datasource-juggler/commit/76ebdcb91bef7638d0f708c3b0bed72b06c17943). It might make sense to separate that into another node module eventually since it'll be a helpful utility for adding promise support across many loopback related modules.