### PR TITLE
Enhance http source mapping for parameters from the REST template

### DIFF
--- a/lib/rest-connector.js
+++ b/lib/rest-connector.js
@@ -56,29 +56,46 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
           for (var i = 0, n = params.length; i < n; i++) {
             if (typeof params[i] === 'string') {
               paramNames.push(params[i]);
-              paramSources.push('query');
+              paramSources.push(null);
             } else if (typeof params[i] === 'object') {
               paramNames.push(params[i].name);
-              paramSources.push(params.source);
+              paramSources.push(params[i].source);
             }
           }
           var fn = builder.operation(paramNames);
           dataSource[f] = fn;
 
+          var path = '/' + f;
           fn.accepts = [];
           fn.shared = true;
           var args = builder.template.compile();
           paramNames.forEach(function(p, index) {
+            var arg = args[p];
+            var source = paramSources[index];
+            if (!source) {
+              source = arg.root;
+              if (source === 'headers') {
+                source = 'header';
+              } else if (source === 'url') {
+                source = 'path';
+              }
+            }
+            if (source === 'path') {
+              /// Need to add path vars to the http url
+              path += '/:' + p;
+            }
             fn.accepts.push({
               arg: p,
-              type: args[p].type,
-              required: args[p].required,
-              http: {source: paramSources[index] || 'query'}
+              type: arg.type,
+              required: arg.required,
+              http: {source: source || 'query'}
             });
           });
           fn.returns = {arg: 'data', type: 'object', root: true};
-          fn.http = {verb: (op.template.method || 'GET').toLowerCase()}
-          // dataSource.defineOperation(f, fn, fn);
+          fn.http = {
+            verb: (op.template.method || 'GET').toLowerCase(),
+            path: path
+          };
           DataAccessObject[f] = fn;
         }
       }

--- a/lib/rest-connector.js
+++ b/lib/rest-connector.js
@@ -48,15 +48,33 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
           if (debug.enabled) {
             debug('Mixing in method: %s %j', f, functions[f]);
           }
-          var fn = builder.operation(functions[f]);
+          var params = functions[f];
+          var paramNames = [];
+          var paramSources = [];
+          // The params can be ['x', 'y'] or [{name: 'x', source: 'header'},
+          // {name: 'y'}]
+          for (var i = 0, n = params.length; i < n; i++) {
+            if (typeof params[i] === 'string') {
+              paramNames.push(params[i]);
+              paramSources.push('query');
+            } else if (typeof params[i] === 'object') {
+              paramNames.push(params[i].name);
+              paramSources.push(params.source);
+            }
+          }
+          var fn = builder.operation(paramNames);
           dataSource[f] = fn;
 
           fn.accepts = [];
           fn.shared = true;
           var args = builder.template.compile();
-          functions[f].forEach(function (p) {
-            fn.accepts.push({arg: p, type: args[p].type,
-              required: args[p].required, http: {source: 'query'}});
+          paramNames.forEach(function(p, index) {
+            fn.accepts.push({
+              arg: p,
+              type: args[p].type,
+              required: args[p].required,
+              http: {source: paramSources[index] || 'query'}
+            });
           });
           fn.returns = {arg: 'data', type: 'object', root: true};
           fn.http = {verb: (op.template.method || 'GET').toLowerCase()}

--- a/lib/template.js
+++ b/lib/template.js
@@ -34,6 +34,7 @@ JsonTemplate.prototype.compile = function () {
   var schema = {};
   traverse(this.template).reduce(function (schema, item) {
     var key = this.key;
+    var root = this.path[0];
     var match = null;
 
     function parse(item) {
@@ -53,7 +54,7 @@ JsonTemplate.prototype.compile = function () {
           required = true;
         }
         var type = param[5]; // Type is param[5]
-        schema[name] = {type: type, required: required};
+        schema[name] = {type: type, required: required, root: root};
         if (param[3] !== undefined) {
           schema[name]['default'] = param[3];
         }

--- a/test/rest-adapter-custom.test.js
+++ b/test/rest-adapter-custom.test.js
@@ -187,7 +187,7 @@ describe('REST connector', function () {
       assert.equal(ds.connector._settings.cert, template.clientCert);
     });
 
-    it('should keep order of prececence: options, top level, and defaults', function (done) {
+    it('should keep order of precedence: options, top level, and defaults', function (done) {
       var spec = require('./request-template.json');
       var template = {
         options : {
@@ -208,7 +208,7 @@ describe('REST connector', function () {
         },
         operations: [
           {template: spec, functions: {
-              m1: ["x"]
+              m1: ['x']
           }}
         ]
       };

--- a/test/rest-adapter-custom.test.js
+++ b/test/rest-adapter-custom.test.js
@@ -33,24 +33,54 @@ describe('REST connector', function () {
       server && server.close(done);
     });
 
-    it('should configure remote methods', function (done) {
+    it('should configure remote methods', function(done) {
       var spec = require('./request-template.json');
       var template = {
         operations: [
-          {template: spec, functions: {
-            m1: ["x", "a", "b"]
-          }}
+          {
+            template: spec, functions: {
+            m1: ["p", "x", "a", {name: 'b', source: 'header'}]
+          }
+          }
         ]
       };
       var ds = new DataSource(require('../lib/rest-connector'), template);
       var model = ds.createModel('rest');
       assert(model.m1);
+      assert.deepEqual(model.m1.accepts, [
+          {
+            arg: 'p',
+            http: {
+              source: 'path'
+            },
+            required: false,
+            type: 'string'
+          },
+          {
+            arg: 'x',
+            type: 'number',
+            required: false,
+            http: {source: 'query'}
+          },
+          {
+            arg: 'a',
+            type: 'number',
+            required: false,
+            http: {source: 'body'}
+          },
+          {
+            arg: 'b',
+            type: 'boolean',
+            required: false,
+            http: {source: 'header'}
+          }]
+      );
       assert(model.m1.shared);
-      assert.deepEqual(model.m1.http, {verb: 'post'});
-      model.m1(3, 5, false, function (err, result) {
+      assert.deepEqual(model.m1.http, {verb: 'post', path: '/m1/:p'});
+      model.m1('1', 3, 5, false, function (err, result) {
         delete result.headers;
         assert.deepEqual(result, { method: 'POST',
-          url: '/?x=3&y=2',
+          url: '/1?x=3&y=2',
           query: { x: '3', y: '2' },
           body: { a: 5, b: false } });
         done(err, result);


### PR DESCRIPTION
The PR introduces the following features. It will be released in 2.0.0.

1. The http source for a given variable will be based on the root property of the template. For example,

  - url --> path
  - query --> query
  - body --> body
  - headers --> header

2. The source can be customized in the parameter array of the function mapping.

  For the following template, we'll now have:
    * p - path
    * x - query
    * a - body
    * b - header
 
3. The path vars will be appended to the path, for example, `/myOp/:p`
```
{
  "template": {
    "method": "POST",
    "url": "http://localhost:3000/{p}",
    "headers": {
      "accept": "application/{format}"
    },
    "query": {
      "x": "{x}",
      "y": 2
    },
    "body": {
      "a": "{a:number}",
      "b": "{b=true}"
    }
  },
  "functions": {
    "myOp": [
      "p",
      "x",
      "a",
      {
        "name": "b",
        "source": "header"
      }
    ]
  }
}
```