### PR TITLE
Update tests to be port independent

### DIFF
--- a/test/express-helper.js
+++ b/test/express-helper.js
@@ -8,7 +8,8 @@ var express = require('express');
 module.exports = function createApp() {
   var app = express();
 
-  app.set('port', process.env.PORT || 3000);
+  // dynamically allocate available PORT if no port provided
+  app.set('port', process.env.PORT || 0);
   app.use(require('body-parser').json());
 
   return app;

--- a/test/rest-adapter-custom.test.js
+++ b/test/rest-adapter-custom.test.js
@@ -13,6 +13,8 @@ var TEST_ADDRESS = /Bedford Ave.*, Brooklyn, NY 11211, USA/;
 describe('REST connector', function() {
   describe('custom operations', function() {
     var server = null;
+    var hostURL = 'http://localhost:';
+
     before(function(done) {
       var app = require('./express-helper')();
 
@@ -29,7 +31,8 @@ describe('REST connector', function() {
       });
 
       server = app.listen(app.get('port'), function(err, data) {
-        // console.log('Server listening on ', app.get('port'));
+        // console.log('Server listening on ', server.address().port);
+        hostURL += server.address().port;
         done(err, data);
       });
     });
@@ -40,6 +43,7 @@ describe('REST connector', function() {
 
     it('should configure remote methods', function(done) {
       var spec = require('./request-template.json');
+      spec.url = hostURL + '/{p}'; // replace template.url to use current host
       var template = {
         operations: [
           {
@@ -55,9 +59,7 @@ describe('REST connector', function() {
       assert.deepEqual(model.m1.accepts, [
         {
           arg: 'p',
-          http: {
-            source: 'path',
-          },
+          http: { source: 'path' },
           required: false,
           type: 'string',
         },

--- a/test/rest-loopback.test.js
+++ b/test/rest-loopback.test.js
@@ -6,26 +6,7 @@
 var assert = require('assert');
 
 var DataSource = require('loopback-datasource-juggler').DataSource;
-var ds = new DataSource(require('../lib/rest-connector'),
-  {
-    baseURL: 'http://localhost:3000',
-    defaults: {
-      headers: {
-        'X-MY-HEADER': 'my-header',
-      },
-    },
-  });
-
-// simplier way to describe model
-var User = ds.define('User', {
-  name: String,
-  bio: String,
-  approved: Boolean,
-  joinedAt: Date,
-  age: Number,
-}, { plural: 'Users' });
-
-ds.attach(User);
+var ds, User;
 
 describe('REST connector', function() {
   describe('CRUD apis', function() {
@@ -34,7 +15,7 @@ describe('REST connector', function() {
       var app = require('./express-helper')();
 
       var count = 2;
-      var users = [new User({ id: 1, name: 'Ray' }), new User({ id: 2, name: 'Joe' })];
+      var users;
 
       app.get('/Users', function(req, res, next) {
         res.setHeader('Content-Type', 'application/json');
@@ -90,9 +71,32 @@ describe('REST connector', function() {
         }
         res.status(404).end();
       });
-
       server = app.listen(app.get('port'), function(err, data) {
-        // console.log('Server listening on ', app.get('port'));
+        ds = new DataSource(require('../lib/rest-connector'),
+          {
+            baseURL: 'http://localhost:' + server.address().port,
+            defaults: {
+              headers: {
+                'X-MY-HEADER': 'my-header',
+              },
+            },
+          });
+
+        // simplier way to describe model
+        User = ds.define('User', {
+          name: String,
+          bio: String,
+          approved: Boolean,
+          joinedAt: Date,
+          age: Number,
+        }, { plural: 'Users' });
+
+        ds.attach(User);
+        users = [
+          new User({ id: 1, name: 'Ray' }),
+          new User({ id: 2, name: 'Joe' }),
+        ];
+        // console.log('Server listening on ', server.address().port);
         done(err, data);
       });
     });

--- a/test/rest-model.test.js
+++ b/test/rest-model.test.js
@@ -19,7 +19,7 @@ var User = modelBuilder.define('User', {
 
 var RestResource = require('../lib/rest-model');
 
-var rest = new RestResource('Users', 'http://localhost:3000');
+var rest;
 
 describe('REST connector', function() {
   describe('CRUD methods supported', function() {
@@ -85,7 +85,9 @@ describe('REST connector', function() {
       });
 
       server = app.listen(app.get('port'), function(err, data) {
-        // console.log('Server listening on ', app.get('port'));
+        // console.log('Server listening on ', server.address().port);
+        rest = new RestResource('Users',
+          'http://localhost:' + server.address().port);
         done(err, data);
       });
     });


### PR DESCRIPTION
Some test cases start a new server
on Port:3000, which results in EADDRINUSE
failure on CI when port:3000 is busy.

This commit addresses above issue by setting
port to `0` which lets the OS to allocate any
avilable port, dynamically, to be used for
starting the server, which makes test cases
more robust.

Connect to strongloop/loopback-connector-rest#64