### PR TITLE
fix: use bluebird for promises

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,19 +3,12 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+var Promise = require('bluebird');
+
 exports.createPromiseCallback = createPromiseCallback;
 
 function createPromiseCallback() {
   var cb;
-
-  if (!global.Promise) {
-    cb = function() {};
-    cb.promise = {};
-    Object.defineProperty(cb.promise, 'then', { get: throwPromiseNotDefined });
-    Object.defineProperty(cb.promise, 'catch', { get: throwPromiseNotDefined });
-    return cb;
-  }
-
   var promise = new Promise(function(resolve, reject) {
     cb = function(err, data) {
       if (err) return reject(err);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Loopback REST Connector",
   "engines": {
     "node": ">=4"
-  },  
+  },
   "keywords": [
     "StrongLoop",
     "LoopBack",
@@ -30,7 +30,7 @@
     "traverse": "^0.6.6"
   },
   "devDependencies": {
-    "bluebird": "^3.3.4",
+    "bluebird": "^3.5.0",
     "body-parser": "^1.12.0",
     "eslint": "^2.7.0",
     "eslint-config-loopback": "^1.0.0",


### PR DESCRIPTION
Fixes #98

### Description
This PR updates to use bluebird for promises, inline with loopback 3.x standards. The updated createPromiseCallback method is a direct copy of the one from loopback 3.x.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
