### PR TITLE
Fix the template to allow stringified json

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -45,12 +45,12 @@ JsonTemplate.prototype.compile = function() {
 
     function parse(item) {
       var matched = false;
-      var templates = /\{([^\{\}]+)\}/g;
+      var templates = /\{(([\!\^]?[a-zA-Z\$_][\w\$]*)\s*(=([^:]+))?(:(\w+))?)\}/g;
       /* eslint-disable no-cond-assign */
       while (match = templates.exec(item)) {
         /* eslint-enable no-cond-assign */
         matched = true;
-        var param = /([^:=\s]+)\s*(=([^:]+))?(:(\w+))?/.exec(match[1]);
+        var param = /([[\!\^]?[a-zA-Z\$_][\w\$]*)\s*(=([^:]+))?(:(\w+))?/.exec(match[1]);
         if (!param || !param[1]) {
           throw new Error(g.f('Invalid parameter: %s', match[1]));
         }
@@ -117,7 +117,7 @@ JsonTemplate.prototype.build = function(parameters) {
 
   function transform(obj) {
     return traverse(obj).map(function(item) {
-      var templates = /\{([^\{\}]+)\}/g;
+      var templates = /\{(([\!\^]?[a-zA-Z\$_][\w\$]*)\s*(=([^:\{\}]+))?(:(\w+))?)\}/g;
       function build(item) {
         var match = null;
         var parsed = [];
@@ -131,7 +131,7 @@ JsonTemplate.prototype.build = function(parameters) {
             parsed.push(item.substring(index, match.index));
           }
           // The variable pattern is {name=defaultValue:type}
-          var param = /([^:=\s]+)\s*(=([^:]+))?(:(\w+))?/.exec(match[1]);
+          var param = /([\!\^]?[a-zA-Z\$_][\w\$]*)\s*(=([^:\{\}]+))?(:(\w+))?/.exec(match[1]);
           if (!param || !param[1]) {
             throw new Error(g.f('Invalid parameter: %s', match[1]));
           }

--- a/test/rest-adapter-custom.test.js
+++ b/test/rest-adapter-custom.test.js
@@ -31,7 +31,7 @@ describe('REST connector', function() {
       });
 
       server = app.listen(app.get('port'), function(err, data) {
-        // console.log('Server listening on ', server.address().port);
+        if (err) return done(err);
         hostURL += server.address().port;
         done(err, data);
       });
@@ -91,6 +91,7 @@ describe('REST connector', function() {
       assert(model.m1.shared);
       assert.deepEqual(model.m1.http, { verb: 'post', path: '/m1/:p' });
       model.m1('1', 3, 5, false, 'zzz', function(err, result) {
+        if (err) return done(err);
         result.headers.should.have.property('x-test', 'zzz');
         delete result.headers;
         assert.deepEqual(result, { method: 'POST',
@@ -129,11 +130,9 @@ describe('REST connector', function() {
       assert(ds.invoke);
       assert(ds.geocode);
       ds.geocode(40.714224, -73.961452, function(err, result, response) {
-        // console.log(response.headers);
+        if (err) return done(err);
         var body = response.body;
         var address = body.results[0].formatted_address;
-        // console.log(address);
-
         assert.ok(address.match(TEST_ADDRESS));
         done(err, address);
       });
@@ -166,16 +165,14 @@ describe('REST connector', function() {
       var ds = new DataSource(require('../lib/rest-connector'), spec);
       assert(ds.getAddress);
       ds.getAddress('40.714224,-73.961452', function(err, result, response) {
+        if (err) return done(err);
         var body = response.body;
         var address = body.results[0].formatted_address;
-        // console.log('Address', address);
         assert.ok(address.match(TEST_ADDRESS));
         assert(ds.getGeoLocation);
         ds.getGeoLocation('107 S B St, San Mateo, CA', function(err, result, response) {
-          // console.log(response.headers);
           var body = response.body;
           var loc = body.results[0].geometry.location;
-          // console.log('Location', loc);
           done(err, loc);
         });
       });
@@ -203,10 +200,9 @@ describe('REST connector', function() {
       var ds = new DataSource(require('../lib/rest-connector'), spec);
       assert(ds.invoke);
       ds.invoke({ latitude: 40.714224, longitude: -73.961452 }, function(err, result, response) {
-        // console.log(response.headers);
+        if (err) return done(err);
         var body = response.body;
         var address = body.results[0].formatted_address;
-        console.log(address);
         assert.ok(address.match(TEST_ADDRESS));
         done(err, address);
       });
@@ -256,6 +252,7 @@ describe('REST connector', function() {
       var ds = new DataSource(require('../lib/rest-connector'), template);
       var model = ds.createModel('rest');
       model.m1(3, function(err, result) {
+        if (err) return done(err);
         assert.equal(result.headers['x-defaults'], 'defaults');
         assert.equal(result.headers['x-options'], 'options');
         assert.equal(result.headers['x-top'], 'top');

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -52,6 +52,18 @@ describe('JsonTemplate', function() {
       done(null, result);
     });
 
+    it('should support variable names starts with $ or _', function(done) {
+      var template = new JsonTemplate({
+        url: 'http://localhost:3000/{$p=100}',
+        query: { x: '{_x=ME}', y: 2 },
+      });
+      var result = template.build({ $p: 1, _x: 'YOU' });
+      assert.equal('http://localhost:3000/1', result.url);
+      assert.equal('YOU', result.query.x);
+      assert.equal(2, result.query.y);
+      done(null, result);
+    });
+
     it('should support typed variables', function(done) {
       var template = new JsonTemplate({
         url: 'http://localhost:3000/{p=100}',
@@ -60,7 +72,6 @@ describe('JsonTemplate', function() {
       });
       var result = template.build({ p: 1, a: 100, b: false });
 
-      // console.log(body);
       assert.equal('http://localhost:3000/1', result.url);
       assert.equal(100, result.query.x);
       assert.equal(2, result.query.y);
@@ -167,6 +178,36 @@ describe('JsonTemplate', function() {
           client_secret: 's1' }});
       /* eslint-enable camelcase */
 
+      done();
+    });
+
+    it('should ignore invalid vars', function(done) {
+      var obj = {
+        url: 'http://localhost:3000/test',
+        headers: {
+          'x-lookup-request': '{x+y}{|}{0a}{=4}',
+        },
+      };
+      var template = new JsonTemplate(obj);
+      var result = template.build(template);
+      result.should.be.eql(obj);
+      done();
+    });
+
+    it('should allow stringified json in headers', function(done) {
+      var obj = {
+        url: 'http://localhost:3000/test',
+        headers: {
+          'x-lookup-request': '{"guid":{"region":"NW","role":"MBR"' +
+          '"userId":"100071974","identifier":[{"id":"000035054016",' +
+          '"source":"KP_EBIZ","idType":"SCALMRN"}]},' +
+          '"relid":[{"region":"SCA","identifier":[{"id":"613637391",' +
+          '"source":"KP_EBIZ","idType":"CID"}]}]}',
+        },
+      };
+      var template = new JsonTemplate(obj);
+      var result = template.build(template);
+      result.should.be.eql(obj);
       done();
     });
   });


### PR DESCRIPTION
The change makes sure the variable names are valid:

1. Starts with $, _, or an ASCII letter
2. Optionally followed by `$`, `_`, letters or digits

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
