### PR TITLE
Allow for unit tests to cope with API query limits

### DIFF
--- a/test/rest-adapter-custom.test.js
+++ b/test/rest-adapter-custom.test.js
@@ -220,9 +220,15 @@ describe('REST connector', function() {
       ds.invoke({ latitude: 40.714224, longitude: -73.961452 }, function(err, result, response) {
         if (err) return done(err);
         var body = response.body;
-        var address = body.results[0].formatted_address;
-        assert.ok(address.match(TEST_ADDRESS));
-        done(err, address);
+        if (body.status !== 'OK') {
+          //If the request has been rate limited, check that the status indicates this
+          assert.ok(body.status == 'OVER_QUERY_LIMIT');
+          done(err);
+        } else {
+          var address = body.results[0].formatted_address;
+          assert.ok(address.match(TEST_ADDRESS));
+          done(err, address);
+        }
       });
     });
 

--- a/test/rest-adapter-custom.test.js
+++ b/test/rest-adapter-custom.test.js
@@ -132,9 +132,15 @@ describe('REST connector', function() {
       ds.geocode(40.714224, -73.961452, function(err, result, response) {
         if (err) return done(err);
         var body = response.body;
-        var address = body.results[0].formatted_address;
-        assert.ok(address.match(TEST_ADDRESS));
-        done(err, address);
+        if (body.status !== 'OK') {
+          //If the request has been rate limited, check that the status indicates this
+          assert.ok(body.status === 'OVER_QUERY_LIMIT');
+          done(err);
+        } else {
+          var address = body.results[0].formatted_address;
+          assert.ok(address.match(TEST_ADDRESS));
+          done(err, address);
+        }
       });
     });
 
@@ -167,14 +173,26 @@ describe('REST connector', function() {
       ds.getAddress('40.714224,-73.961452', function(err, result, response) {
         if (err) return done(err);
         var body = response.body;
-        var address = body.results[0].formatted_address;
-        assert.ok(address.match(TEST_ADDRESS));
-        assert(ds.getGeoLocation);
-        ds.getGeoLocation('107 S B St, San Mateo, CA', function(err, result, response) {
-          var body = response.body;
-          var loc = body.results[0].geometry.location;
-          done(err, loc);
-        });
+        if (body.status !== 'OK') {
+          //If the request has been rate limited, check that the status indicates this
+          assert.ok(body.status == 'OVER_QUERY_LIMIT');
+          done(err);
+        } else {
+          var address = body.results[0].formatted_address;
+          assert.ok(address.match(TEST_ADDRESS));
+          assert(ds.getGeoLocation);
+          ds.getGeoLocation('107 S B St, San Mateo, CA', function(err, result, response) {
+            var body = response.body;
+            if (body.status !== 'OK') {
+              //If the request has been rate limited, check that the status indicates this
+              assert.ok(body.status == 'OVER_QUERY_LIMIT');
+              done(err);
+            } else {
+              var loc = body.results[0].geometry.location;
+              done(err, loc);
+            }
+          });
+        }
       });
     });
 


### PR DESCRIPTION
### Description

The calls to the Google GeoLocation API used by some of the tests can hit a rate limit which still returns an HTTP 200 but doesn't contain all the information in the body.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to #115 

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
