### PR TITLE
Update dependencies to latest

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,12 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+'use strict';
+
 module.exports = require('./lib/rest-builder');
 
-var connector = require('./lib/rest-connector');
-var SG = require('strong-globalize');
+const connector = require('./lib/rest-connector');
+const SG = require('strong-globalize');
 SG.SetRootDir(__dirname);
 
 module.exports.RestConnector = connector.RestConnector;

--- a/lib/experimental/json-schema-discovery.js
+++ b/lib/experimental/json-schema-discovery.js
@@ -3,6 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+'use strict';
+
 var traverse = require('traverse');
 
 exports.discoverModelDefinitions = discoverModelDefinitions;
@@ -28,7 +30,7 @@ function discoverModelDefinitions(json, options) {
 
     var name = this.key ? this.key : 'root';
     if (type === 'object' || type === 'array') {
-      var s = { name: name, properties: {}};
+      var s = {name: name, properties: {}};
       stack[this.level] = s;
       schemas.push(s);
       if (type === 'object') {

--- a/lib/experimental/rest-swagger.js
+++ b/lib/experimental/rest-swagger.js
@@ -3,6 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+'use strict';
+
 var JsonTemplate = require('./../template');
 
 var spec = require('./rest-spec.json');

--- a/lib/rest-builder.js
+++ b/lib/rest-builder.js
@@ -3,6 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+'use strict';
+
 /*!
  * REST request spec builder
  */
@@ -581,7 +583,7 @@ RequestBuilder.prototype._request = function(uri, options, cb) {
   if (options && typeof options === 'object') {
     options.uri = uri;
   } else if (typeof uri === 'string') {
-    options = { uri: uri };
+    options = {uri: uri};
   } else {
     options = uri;
   }
@@ -592,7 +594,7 @@ RequestBuilder.prototype._request = function(uri, options, cb) {
     return this.request(options, callback);
   }
   var self = this;
-  var context = { request: self.request, req: options };
+  var context = {request: self.request, req: options};
 
   function work(context, done) {
     self.request(options, function(err, res, body) {

--- a/lib/rest-builder.js
+++ b/lib/rest-builder.js
@@ -181,7 +181,7 @@ RequestBuilder.prototype.header = function(field, val) {
 };
 
 /**
- * Set _Content-Type_ response header passed through `mime.lookup()`.
+ * Set _Content-Type_ response header passed through `mime.getType()`.
  *
  * Examples:
  *
@@ -203,7 +203,7 @@ RequestBuilder.prototype.header = function(field, val) {
 
 RequestBuilder.prototype.type = function(type) {
   return this.header('Content-Type', ~type.indexOf('/') ?
-    type : mime.lookup(type));
+    type : mime.getType(type));
 };
 
 RequestBuilder.prototype.cookie = function(cookie) {

--- a/lib/rest-connector.js
+++ b/lib/rest-connector.js
@@ -3,6 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+'use strict';
+
 var debug = require('debug')('loopback:connector:rest');
 var RestResource = require('./rest-model');
 var RequestBuilder = require('./rest-builder');
@@ -35,10 +37,10 @@ function initializeDataSource(dataSource, callback) {
   // Copy the methods from default DataAccessObject
   if (!settings.operations || settings.crud) {
     if (dataSource.constructor.DataAccessObject) {
-      for (var i in dataSource.constructor.DataAccessObject) {
+      for (const i in dataSource.constructor.DataAccessObject) {
         DataAccessObject[i] = dataSource.constructor.DataAccessObject[i];
       }
-      for (var i in dataSource.constructor.DataAccessObject.prototype) {
+      for (const i in dataSource.constructor.DataAccessObject.prototype) {
         DataAccessObject.prototype[i] = dataSource.constructor.DataAccessObject.prototype[i];
       }
       /* eslint-enable one-var */
@@ -101,10 +103,10 @@ function initializeDataSource(dataSource, callback) {
               arg: p,
               type: arg.type,
               required: arg.required,
-              http: { source: source || 'query' },
+              http: {source: source || 'query'},
             });
           });
-          fn.returns = { arg: 'data', type: 'object', root: true };
+          fn.returns = {arg: 'data', type: 'object', root: true};
           fn.http = {
             verb: (op.template.method || 'GET').toLowerCase(),
             path: path,
@@ -124,7 +126,7 @@ function initializeDataSource(dataSource, callback) {
 
       dataSource[name] = invokeFn;
       invokeFn.accepts = [
-        { name: 'request', type: 'object' },
+        {name: 'request', type: 'object'},
       ];
       invokeFn.shared = true;
       // dataSource.defineOperation(name, fn, fn);
@@ -132,7 +134,7 @@ function initializeDataSource(dataSource, callback) {
     });
   }
 
-  callback && process.nextTick(callback);
+  if (callback) process.nextTick(callback);
 };
 
 /**
@@ -273,14 +275,14 @@ RestConnector.prototype.getResource = function getResourceUrl(model) {
 RestConnector.prototype.create = function create(model, data, callback) {
   this.getResource(model).create(data, function(err, body, response) {
     if (err) {
-      callback && callback(err, body);
+      if (callback) callback(err, body);
       return;
     }
     if (response.statusCode === 200 || response.statusCode === 201) {
-      callback && callback(null, body.id);
+      if (callback) callback(null, body.id);
     } else {
-      var err = g.f('Error response: %d %j', response.statusCode, body);
-      callback && callback(err);
+      err = g.f('Error response: %d %j', response.statusCode, body);
+      if (callback) callback(err);
     }
   });
 };
@@ -315,7 +317,7 @@ RestConnector.prototype.responseHandler = function(model, callback, many) {
   var self = this;
   return function(err, body, response) {
     if (err) {
-      callback && callback(err, body);
+      if (callback) callback(err, body);
       return;
     }
     if (response.statusCode === 200) {
@@ -324,8 +326,8 @@ RestConnector.prototype.responseHandler = function(model, callback, many) {
         callback(null, result);
       }
     } else {
-      var err = g.f('Error response: %d %j', response.statusCode, body);
-      callback && callback(err);
+      err = g.f('Error response: %d %j', response.statusCode, body);
+      if (callback) callback(err);
     }
   };
 };
@@ -349,16 +351,16 @@ RestConnector.prototype.save = function save(model, data, callback) {
 RestConnector.prototype.exists = function exists(model, id, callback) {
   this.getResource(model).find(id, function(err, body, response) {
     if (err) {
-      callback && callback(err, body);
+      if (callback) callback(err, body);
       return;
     }
     if (response.statusCode === 200) {
-      callback && callback(null, true);
+      if (callback) callback(null, true);
     } else if (response.statusCode === 404) {
-      callback && callback(null, false);
+      if (callback) callback(null, false);
     } else {
-      var err = g.f('Error response: %s %j', response.statusCode, body);
-      callback && callback(err);
+      err = g.f('Error response: %s %j', response.statusCode, body);
+      if (callback) callback(err);
     }
   });
 };
@@ -404,7 +406,7 @@ RestConnector.prototype.all = function all(model, filter, callback) {
             result = [result];
           }
         }
-        callback && callback(err, result);
+        if (callback) callback(err, result);
       });
     }
   }

--- a/lib/rest-model.js
+++ b/lib/rest-model.js
@@ -3,6 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+'use strict';
+
 var debug = require('debug')('loopback:connector:rest');
 var request = require('request');
 var g = require('strong-globalize')();
@@ -204,6 +206,4 @@ function defineFunctions() {
   });
   return functions;
 }
-
-
 

--- a/lib/template.js
+++ b/lib/template.js
@@ -3,6 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+'use strict';
+
 var traverse = require('traverse');
 var debug = require('debug')('loopback:connector:rest');
 var g = require('strong-globalize')();
@@ -62,7 +64,7 @@ JsonTemplate.prototype.compile = function() {
           required = true;
         }
         var type = param[5]; // Type is param[5]
-        schema[name] = { type: type, required: required, root: root };
+        schema[name] = {type: type, required: required, root: root};
         if (param[3] !== undefined) {
           schema[name]['default'] = param[3];
         }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,11 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+'use strict';
+
+const SG = require('strong-globalize');
+const g = SG();
+
 exports.createPromiseCallback = createPromiseCallback;
 
 function createPromiseCallback() {
@@ -11,8 +16,8 @@ function createPromiseCallback() {
   if (!global.Promise) {
     cb = function() {};
     cb.promise = {};
-    Object.defineProperty(cb.promise, 'then', { get: throwPromiseNotDefined });
-    Object.defineProperty(cb.promise, 'catch', { get: throwPromiseNotDefined });
+    Object.defineProperty(cb.promise, 'then', {get: throwPromiseNotDefined});
+    Object.defineProperty(cb.promise, 'catch', {get: throwPromiseNotDefined});
     return cb;
   }
 

--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
     "posttest": "npm run lint"
   },
   "dependencies": {
-    "debug": "^2.1.1",
+    "debug": "^3.1.0",
     "jsonpath-plus": "^0.14.0",
     "lodash": "^4.6.1",
     "methods": "^1.1.1",
-    "mime": "^1.3.4",
+    "mime": "^2.3.1",
     "qs": "^6.1.0",
     "request": "^2.53.0",
-    "strong-globalize": "^2.6.0",
+    "strong-globalize": "^3.3.0",
     "traverse": "^0.6.6"
   },
   "devDependencies": {
@@ -37,8 +37,8 @@
     "eslint-plugin-mocha": "^4.12.1",
     "express": "^4.12.0",
     "loopback-datasource-juggler": "^3.0.0",
-    "mocha": "^2.1.0",
-    "should": "^8.2.2"
+    "mocha": "^5.2.0",
+    "should": "^13.2.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,9 @@
   "devDependencies": {
     "bluebird": "^3.3.4",
     "body-parser": "^1.12.0",
-    "eslint": "^2.7.0",
-    "eslint-config-loopback": "^1.0.0",
+    "eslint": "^4.19.1",
+    "eslint-config-loopback": "^10.0.0",
+    "eslint-plugin-mocha": "^4.12.1",
     "express": "^4.12.0",
     "loopback-datasource-juggler": "^3.0.0",
     "mocha": "^2.1.0",

--- a/test/express-helper.js
+++ b/test/express-helper.js
@@ -3,6 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+'use strict';
+
 var express = require('express');
 
 module.exports = function createApp() {

--- a/test/rest-adapter-custom.test.js
+++ b/test/rest-adapter-custom.test.js
@@ -3,6 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+'use strict';
+
 var assert = require('assert');
 var should = require('should');
 
@@ -38,7 +40,7 @@ describe('REST connector', function() {
     });
 
     after(function(done) {
-      server && server.close(done);
+      if (server) server.close(done);
     });
 
     it('should configure remote methods', function(done) {
@@ -48,7 +50,7 @@ describe('REST connector', function() {
         operations: [
           {
             template: spec, functions: {
-              m1: ['p', 'x', 'a', { name: 'b', source: 'header' }, 'z'],
+              m1: ['p', 'x', 'a', {name: 'b', source: 'header'}, 'z'],
             },
           },
         ],
@@ -59,7 +61,7 @@ describe('REST connector', function() {
       assert.deepEqual(model.m1.accepts, [
         {
           arg: 'p',
-          http: { source: 'path' },
+          http: {source: 'path'},
           required: false,
           type: 'string',
         },
@@ -67,37 +69,37 @@ describe('REST connector', function() {
           arg: 'x',
           type: 'number',
           required: false,
-          http: { source: 'query' },
+          http: {source: 'query'},
         },
         {
           arg: 'a',
           type: 'number',
           required: false,
-          http: { source: 'body' },
+          http: {source: 'body'},
         },
         {
           arg: 'b',
           type: 'boolean',
           required: false,
-          http: { source: 'header' },
+          http: {source: 'header'},
         },
         {
           arg: 'z',
           type: 'string',
           required: false,
-          http: { source: 'header' },
+          http: {source: 'header'},
         }]
       );
       assert(model.m1.shared);
-      assert.deepEqual(model.m1.http, { verb: 'post', path: '/m1/:p' });
+      assert.deepEqual(model.m1.http, {verb: 'post', path: '/m1/:p'});
       model.m1('1', 3, 5, false, 'zzz', function(err, result) {
         if (err) return done(err);
         result.headers.should.have.property('x-test', 'zzz');
         delete result.headers;
-        assert.deepEqual(result, { method: 'POST',
+        assert.deepEqual(result, {method: 'POST',
           url: '/1?x=3&y=2',
-          query: { x: '3', y: '2' },
-          body: { a: 5, b: false }});
+          query: {x: '3', y: '2'},
+          body: {a: 5, b: false}});
         done(err, result);
       });
     });
@@ -125,7 +127,7 @@ describe('REST connector', function() {
               'geocode': ['latitude', 'longitude'],
             },
           },
-        ] };
+        ]};
       var ds = new DataSource(require('../lib/rest-connector'), spec);
       assert(ds.invoke);
       assert(ds.geocode);
@@ -160,7 +162,7 @@ describe('REST connector', function() {
               'getGeoLocation': ['address'],
             },
           },
-        ] };
+        ]};
       var ds = new DataSource(require('../lib/rest-connector'), spec);
       assert(ds.getAddress);
       ds.getAddress('40.714224,-73.961452', function(err, body, response) {
@@ -194,10 +196,10 @@ describe('REST connector', function() {
               },
             },
           },
-        ] };
+        ]};
       var ds = new DataSource(require('../lib/rest-connector'), spec);
       assert(ds.invoke);
-      ds.invoke({ latitude: 40.714224, longitude: -73.961452 }, function(err, body, response) {
+      ds.invoke({latitude: 40.714224, longitude: -73.961452}, function(err, body, response) {
         if (!checkGoogleMapAPIResult(err, response, done)) return;
         var address = body.results[0].formatted_address;
         assert.ok(address.match(TEST_ADDRESS));
@@ -211,7 +213,7 @@ describe('REST connector', function() {
         clientKey: 'CLIENT.KEY',
         clientCert: 'CLIENT.CERT',
         operations: [
-          { template: spec, functions: {
+          {template: spec, functions: {
             m1: ['x'],
           }},
         ],
@@ -241,7 +243,7 @@ describe('REST connector', function() {
           },
         },
         operations: [
-          { template: spec, functions: {
+          {template: spec, functions: {
             m1: ['x'],
           }},
         ],

--- a/test/rest-builder.test.js
+++ b/test/rest-builder.test.js
@@ -3,6 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+'use strict';
+
 var assert = require('assert');
 
 if (!global.Promise) {
@@ -38,13 +40,13 @@ describe('REST Request Builder', function() {
     });
 
     after(function(done) {
-      server && server.close(done);
+      if (server) server.close(done);
     });
 
     it('should substitute the variables', function(done) {
       var builder = new RequestBuilder('GET', hostURL + '/{p}')
-        .query({ x: '{x}', y: 2 });
-      builder.invoke({ p: 1, x: 'X' },
+        .query({x: '{x}', y: 2});
+      builder.invoke({p: 1, x: 'X'},
         function(err, body, response) {
           assert.equal(200, response.statusCode);
           if (typeof body === 'string') {
@@ -57,8 +59,8 @@ describe('REST Request Builder', function() {
     });
 
     it('should support default variables', function(done) {
-      var builder = new RequestBuilder('GET', hostURL + '/{p=100}').query({ x: '{x=ME}', y: 2 });
-      builder.invoke({ p: 1 },
+      var builder = new RequestBuilder('GET', hostURL + '/{p=100}').query({x: '{x=ME}', y: 2});
+      builder.invoke({p: 1},
         function(err, body, response) {
           assert.equal(200, response.statusCode);
           if (typeof body === 'string') {
@@ -72,9 +74,9 @@ describe('REST Request Builder', function() {
     });
 
     it('should support typed variables', function(done) {
-      var builder = new RequestBuilder('POST', hostURL + '/{p=100}').query({ x: '{x=100:number}', y: 2 })
-        .body({ a: '{a=1:number}', b: '{b=true:boolean}' });
-      builder.invoke({ p: 1, a: 100, b: false },
+      var builder = new RequestBuilder('POST', hostURL + '/{p=100}').query({x: '{x=100:number}', y: 2})
+        .body({a: '{a=1:number}', b: '{b=true:boolean}'});
+      builder.invoke({p: 1, a: 100, b: false},
         function(err, body, response) {
           assert.equal(200, response.statusCode);
           if (typeof body === 'string') {
@@ -90,10 +92,10 @@ describe('REST Request Builder', function() {
     });
 
     it('should report missing required variables', function(done) {
-      var builder = new RequestBuilder('POST', hostURL + '/{!p}').query({ x: '{x=100:number}', y: 2 })
-        .body({ a: '{^a:number}', b: '{!b=true:boolean}' });
+      var builder = new RequestBuilder('POST', hostURL + '/{!p}').query({x: '{x=100:number}', y: 2})
+        .body({a: '{^a:number}', b: '{!b=true:boolean}'});
       try {
-        builder.invoke({ a: 100, b: false },
+        builder.invoke({a: 100, b: false},
           function(err, body, response) {
             // console.log(response.headers);
             assert.equal(200, response.statusCode);
@@ -111,10 +113,10 @@ describe('REST Request Builder', function() {
     });
 
     it('should support required variables', function(done) {
-      var builder = new RequestBuilder('POST', hostURL + '/{!p}').query({ x: '{x=100:number}', y: 2 })
-        .body({ a: '{^a:number}', b: '{!b=true:boolean}' });
+      var builder = new RequestBuilder('POST', hostURL + '/{!p}').query({x: '{x=100:number}', y: 2})
+        .body({a: '{^a:number}', b: '{!b=true:boolean}'});
 
-      builder.invoke({ p: 1, a: 100, b: false },
+      builder.invoke({p: 1, a: 100, b: false},
         function(err, body, response) {
           // console.log(response.headers);
           assert.equal(200, response.statusCode);
@@ -132,7 +134,7 @@ describe('REST Request Builder', function() {
     });
 
     it('should build an operation with the parameter names', function(done) {
-      var builder = new RequestBuilder('POST', hostURL + '/{p}').query({ x: '{x}', y: 2 });
+      var builder = new RequestBuilder('POST', hostURL + '/{p}').query({x: '{x}', y: 2});
 
       var fn = builder.operation(['p', 'x']);
 
@@ -152,7 +154,7 @@ describe('REST Request Builder', function() {
     });
 
     it('should build an operation with the parameter names as args', function(done) {
-      var builder = new RequestBuilder('POST', hostURL + '/{p}').query({ x: '{x}', y: 2 });
+      var builder = new RequestBuilder('POST', hostURL + '/{p}').query({x: '{x}', y: 2});
 
       var fn = builder.operation('p', 'x');
 
@@ -176,7 +178,7 @@ describe('REST Request Builder', function() {
       template.url = hostURL + '/{p}'; // update template.url to dynamic host
       var builder = new RequestBuilder(template);
       // console.log(builder.parse());
-      builder.invoke({ p: 1, a: 100, b: false },
+      builder.invoke({p: 1, a: 100, b: false},
         function(err, body, response) {
           // console.log(response.headers);
           assert.equal(200, response.statusCode);
@@ -194,11 +196,11 @@ describe('REST Request Builder', function() {
     });
 
     it('should support custom request funciton', function(done) {
-      var requestFunc = require('request').defaults({ headers: { 'X-MY-HEADER': 'my-header' }});
+      var requestFunc = require('request').defaults({headers: {'X-MY-HEADER': 'my-header'}});
       var builder = new RequestBuilder(require('./request-template.json'),
         requestFunc);
       // console.log(builder.parse());
-      builder.invoke({ p: 1, a: 100, b: false },
+      builder.invoke({p: 1, a: 100, b: false},
         function(err, body, response) {
           // console.log(response.headers);
           assert.equal(200, response.statusCode);
@@ -211,7 +213,7 @@ describe('REST Request Builder', function() {
   describe('invoke', function() {
     it('should return a promise when no callback is specified', function() {
       var builder = new RequestBuilder(require('./request-template.json'));
-      var promise = builder.invoke({ p: 1, a: 100, b: false });
+      var promise = builder.invoke({p: 1, a: 100, b: false});
       assert(typeof promise['then'] === 'function');
       assert(typeof promise['catch'] === 'function');
       return promise.catch(function(err) {
@@ -247,7 +249,7 @@ describe('REST Request Builder', function() {
     });
 
     after(function(done) {
-      server && server.close(done);
+      if (server) server.close(done);
     });
 
     it('should consider the response an error', function(done) {

--- a/test/rest-loopback.test.js
+++ b/test/rest-loopback.test.js
@@ -3,6 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+'use strict';
+
 var assert = require('assert');
 
 var DataSource = require('loopback-datasource-juggler').DataSource;
@@ -89,12 +91,12 @@ describe('REST connector', function() {
           approved: Boolean,
           joinedAt: Date,
           age: Number,
-        }, { plural: 'Users' });
+        }, {plural: 'Users'});
 
         ds.attach(User);
         users = [
-          new User({ id: 1, name: 'Ray' }),
-          new User({ id: 2, name: 'Joe' }),
+          new User({id: 1, name: 'Ray'}),
+          new User({id: 2, name: 'Joe'}),
         ];
         // console.log('Server listening on ', server.address().port);
         done(err, data);
@@ -102,7 +104,7 @@ describe('REST connector', function() {
     });
 
     after(function(done) {
-      server && server.close(done);
+      if (server) server.close(done);
     });
 
     it('should find two users', function(done) {
@@ -163,7 +165,7 @@ describe('REST connector', function() {
     });
 
     it('should create a new id named Mary', function(done) {
-      User.create({ name: 'Mary' }, function(err, body) {
+      User.create({name: 'Mary'}, function(err, body) {
         // console.log(body);
         done(err, body);
       });

--- a/test/rest-model.test.js
+++ b/test/rest-model.test.js
@@ -3,6 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+'use strict';
+
 var assert = require('assert');
 
 var ModelBuilder = require('loopback-datasource-juggler').ModelBuilder;
@@ -28,7 +30,7 @@ describe('REST connector', function() {
       var app = require('./express-helper')();
 
       var count = 2;
-      var users = [new User({ id: 1, name: 'Ray' }), new User({ id: 2, name: 'Joe' })];
+      var users = [new User({id: 1, name: 'Ray'}), new User({id: 2, name: 'Joe'})];
 
       app.get('/Users', function(req, res, next) {
         res.setHeader('Content-Type', 'application/json');
@@ -93,7 +95,7 @@ describe('REST connector', function() {
     });
 
     after(function(done) {
-      server && server.close(done);
+      if (server) server.close(done);
     });
 
     it('should find two users', function(done) {
@@ -126,7 +128,7 @@ describe('REST connector', function() {
     });
 
     it('should update user 1', function(done) {
-      rest.update(1, new User({ id: 1, name: 'Raymond' }), function(err, body, response) {
+      rest.update(1, new User({id: 1, name: 'Raymond'}), function(err, body, response) {
         assert.equal(200, response.statusCode);
         // console.log(err, response && response.statusCode);
         done(err, body);
@@ -142,7 +144,7 @@ describe('REST connector', function() {
     });
 
     it('should create a new id named Mary', function(done) {
-      rest.create(new User({ name: 'Mary' }), function(err, body, response) {
+      rest.create(new User({name: 'Mary'}), function(err, body, response) {
         assert.equal(201, response.statusCode);
         // console.log(response && response.statusCode);
         // console.log(response && response.headers['location']);

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -3,6 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+'use strict';
+
 var assert = require('assert');
 var should = require('should');
 
@@ -13,9 +15,9 @@ describe('JsonTemplate', function() {
     it('should substitute the variables', function(done) {
       var template = new JsonTemplate({
         url: 'http://localhost:3000/{p}',
-        query: { x: '{x}', y: 2 },
+        query: {x: '{x}', y: 2},
       });
-      var result = template.build({ p: 1, x: 'X' });
+      var result = template.build({p: 1, x: 'X'});
       assert.equal('http://localhost:3000/1', result.url);
       assert.equal('X', result.query.x);
       assert.equal(2, result.query.y);
@@ -25,14 +27,14 @@ describe('JsonTemplate', function() {
     it('should substitute the variables independently', function(done) {
       var template = new JsonTemplate({
         url: 'http://localhost:3000/{p}',
-        query: { x: '{x}', y: 2 },
+        query: {x: '{x}', y: 2},
       });
-      var result = template.build({ p: 1, x: 'X' });
+      var result = template.build({p: 1, x: 'X'});
       assert.equal('http://localhost:3000/1', result.url);
       assert.equal('X', result.query.x);
       assert.equal(2, result.query.y);
 
-      result = template.build({ p: 2, x: 'X2' });
+      result = template.build({p: 2, x: 'X2'});
       assert.equal('http://localhost:3000/2', result.url);
       assert.equal('X2', result.query.x);
       assert.equal(2, result.query.y);
@@ -43,9 +45,9 @@ describe('JsonTemplate', function() {
     it('should support default variables', function(done) {
       var template = new JsonTemplate({
         url: 'http://localhost:3000/{p=100}',
-        query: { x: '{x=ME}', y: 2 },
+        query: {x: '{x=ME}', y: 2},
       });
-      var result = template.build({ p: 1 });
+      var result = template.build({p: 1});
       assert.equal('http://localhost:3000/1', result.url);
       assert.equal('ME', result.query.x);
       assert.equal(2, result.query.y);
@@ -55,9 +57,9 @@ describe('JsonTemplate', function() {
     it('should support variable names starts with $ or _', function(done) {
       var template = new JsonTemplate({
         url: 'http://localhost:3000/{$p=100}',
-        query: { x: '{_x=ME}', y: 2 },
+        query: {x: '{_x=ME}', y: 2},
       });
-      var result = template.build({ $p: 1, _x: 'YOU' });
+      var result = template.build({$p: 1, _x: 'YOU'});
       assert.equal('http://localhost:3000/1', result.url);
       assert.equal('YOU', result.query.x);
       assert.equal(2, result.query.y);
@@ -67,10 +69,10 @@ describe('JsonTemplate', function() {
     it('should support typed variables', function(done) {
       var template = new JsonTemplate({
         url: 'http://localhost:3000/{p=100}',
-        query: { x: '{x=100:number}', y: 2 },
-        body: { a: '{a=1:number}', b: '{b=true:boolean}', c: '{c=[99]:json}' },
+        query: {x: '{x=100:number}', y: 2},
+        body: {a: '{a=1:number}', b: '{b=true:boolean}', c: '{c=[99]:json}'},
       });
-      var result = template.build({ p: 1, a: 100, b: false });
+      var result = template.build({p: 1, a: 100, b: false});
 
       assert.equal('http://localhost:3000/1', result.url);
       assert.equal(100, result.query.x);
@@ -85,11 +87,11 @@ describe('JsonTemplate', function() {
     it('should report missing required variables', function(done) {
       var template = new JsonTemplate({
         url: 'http://localhost:3000/{!p}',
-        query: { x: '{x=100:number}', y: 2 },
-        body: { a: '{^a:number}', b: '{!b=true:boolean}' },
+        query: {x: '{x=100:number}', y: 2},
+        body: {a: '{^a:number}', b: '{!b=true:boolean}'},
       });
       try {
-        var result = template.build({ a: 100, b: false });
+        var result = template.build({a: 100, b: false});
         assert.fail();
       } catch (err) {
         // This is expected
@@ -100,10 +102,10 @@ describe('JsonTemplate', function() {
     it('should support required variables', function(done) {
       var template = new JsonTemplate({
         url: 'http://localhost:3000/{!p}',
-        query: { x: '{x=100:number}', y: 2 },
-        body: { a: '{^a:number}', b: '{!b=true:boolean}' },
+        query: {x: '{x=100:number}', y: 2},
+        body: {a: '{^a:number}', b: '{!b=true:boolean}'},
       });
-      var result = template.build({ p: 1, a: 100, b: false });
+      var result = template.build({p: 1, a: 100, b: false});
 
       assert.equal('http://localhost:3000/1', result.url);
       assert.equal(100, result.query.x);
@@ -116,10 +118,10 @@ describe('JsonTemplate', function() {
     it('should support object variables', function(done) {
       var template = new JsonTemplate({
         url: 'http://localhost:3000/{!p}',
-        query: { x: '{x=100:number}', y: 2 },
+        query: {x: '{x=100:number}', y: 2},
         body: '{body}',
       });
-      var result = template.build({ p: 1, body: { a: 100, b: false }});
+      var result = template.build({p: 1, body: {a: 100, b: false}});
 
       assert.equal('http://localhost:3000/1', result.url);
       assert.equal(100, result.query.x);
@@ -136,9 +138,9 @@ describe('JsonTemplate', function() {
           body: '{body}',
         });
 
-        var bodyContent = { id: 1, template: 'this is a normal content with ${var} variables' };
+        var bodyContent = {id: 1, template: 'this is a normal content with ${var} variables'};
 
-        var result = template.build({ body: bodyContent });
+        var result = template.build({body: bodyContent});
         assert.equal(bodyContent, result.body);
         done(null, result);
       });
@@ -146,10 +148,10 @@ describe('JsonTemplate', function() {
     it('should support array variables', function(done) {
       var template = new JsonTemplate({
         url: 'http://localhost:3000/{!p}',
-        query: { x: '{x=100:number}', y: 2 },
+        query: {x: '{x=100:number}', y: 2},
         body: [1, 2, '{z:number}'],
       });
-      var result = template.build({ p: 1, z: 3 });
+      var result = template.build({p: 1, z: 3});
 
       assert.equal('http://localhost:3000/1', result.url);
       assert.equal(100, result.query.x);
@@ -164,18 +166,18 @@ describe('JsonTemplate', function() {
       var json = require('./request-template-with-key-var.json');
 
       var template = new JsonTemplate(json);
-      var result = template.build({ uniqueId: 1, email: 'x@y.com',
-        clientId: 'c1', clientSecret: 's1' });
+      var result = template.build({uniqueId: 1, email: 'x@y.com',
+        clientId: 'c1', clientSecret: 's1'});
       /* eslint-disable camelcase */
-      result.should.be.eql({ method: 'POST',
+      result.should.be.eql({method: 'POST',
         url: 'https://example.com/v1/authenticate',
-        body: { auth_data: { '1': {
+        body: {auth_data: {'1': {
           emailAddress: 'x@y.com',
           id: 'third_party',
         }},
-          grant_type: 'client_credentials',
-          client_id: 'c1',
-          client_secret: 's1' }});
+        grant_type: 'client_credentials',
+        client_id: 'c1',
+        client_secret: 's1'}});
       /* eslint-enable camelcase */
 
       done();


### PR DESCRIPTION
### Description

- Update eslint + config to latest
- Update dependencies to latest

Dependencies not updated:

 - `eslint-plugin-mocha` stays at 4.12.1 because 5.0.0 dropped support for Node.js 4.x that we still support
 - `jsonpath-plus` stays at 0.14.0 because I am not able to evaluate whether their [breaking changes](https://github.com/s3u/JSONPath/blob/v0.16.0/CHANGES.md) would be a breaking change for our consumers

#### Related issues

Done as part of https://github.com/strongloop/loopback-next/pull/1347

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)