### PR TITLE
Add support for default values in function definitions

### DIFF
--- a/lib/rest-builder.js
+++ b/lib/rest-builder.js
@@ -433,6 +433,16 @@ RequestBuilder.prototype.operation = function(parameterNames) {
       cb = arguments[arguments.length - 1];
       size--;
     }
+
+    // set parameter defaults with "paramName=defaultValue" syntax
+    for (var p = 0; p < params.length; p++){
+      if(params[p] && params[p].includes("=")){
+        var paramName = params[p].split("=")[0]
+        var paramDefaultVal = params[p].split("=")[1]
+        parameters[paramName] = paramDefaultVal
+      }
+    }
+
     for (var i = 0; i < size; i++) {
       if (params[i]) {
         parameters[params[i]] = arguments[i];

--- a/lib/rest-builder.js
+++ b/lib/rest-builder.js
@@ -435,11 +435,11 @@ RequestBuilder.prototype.operation = function(parameterNames) {
     }
 
     // set parameter defaults with "paramName=defaultValue" syntax
-    for (var p = 0; p < params.length; p++){
-      if(params[p] && params[p].includes("=")){
-        var paramName = params[p].split("=")[0]
-        var paramDefaultVal = params[p].split("=")[1]
-        parameters[paramName] = paramDefaultVal
+    for (var p = 0; p < params.length; p++) {
+      if (params[p] && params[p].includes('=')) {
+        var paramName = params[p].split('=')[0];
+        var paramDefaultVal = params[p].split('=')[1];
+        parameters[paramName] = paramDefaultVal;
       }
     }
 

--- a/lib/rest-connector.js
+++ b/lib/rest-connector.js
@@ -85,7 +85,7 @@ function initializeDataSource(dataSource, callback) {
           fn.shared = true;
           var args = builder.template.compile();
           paramNames.forEach(function(p, index) {
-            if(p.includes("=")) p = p.split("=")[0]
+            if (p.includes('=')) p = p.split('=')[0];
 
             var arg = args[p];
             var source = paramSources[index];

--- a/lib/rest-connector.js
+++ b/lib/rest-connector.js
@@ -85,6 +85,8 @@ function initializeDataSource(dataSource, callback) {
           fn.shared = true;
           var args = builder.template.compile();
           paramNames.forEach(function(p, index) {
+            if(p.includes("=")) p = p.split("=")[0]
+
             var arg = args[p];
             var source = paramSources[index];
             if (!source) {

--- a/test/rest-adapter-custom.test.js
+++ b/test/rest-adapter-custom.test.js
@@ -187,6 +187,50 @@ describe('REST connector', function() {
       });
     });
 
+    it('should mix in custom path in all functions', function(done) {
+      const TEST_ADDRESS = '107 S B St, San Mateo, CA 94401, USA';
+      const TEST_TIMEZONE = /.*Australia.*/;
+      var spec = {
+        debug: false,
+        operations: [
+          {
+            template: {
+              'method': 'GET',
+              'url': 'https://maps.googleapis.com/maps/api/{path}/{format=json}',
+              'headers': {
+                'accept': 'application/json',
+                'content-type': 'application/json',
+              },
+              'query': {
+                'address': '{address}',
+                'location': '{location}',
+                'timestamp': '1514768461',
+              },
+            },
+            functions: {
+              'getAddress': ['address', 'path=geocode'],
+              'getTimezone': ['location', 'path=timezone'],
+            },
+          },
+        ]};
+      var ds = new DataSource(require('../lib/rest-connector'), spec);
+      assert(ds.getAddress);
+      ds.getAddress('107 S B St, San Mateo, CA', function(err, body, response) {
+        if (!checkGoogleMapAPIResult(err, response, done)) return;
+        var address = body.results[0].formatted_address;
+        assert.ok(address.match(TEST_ADDRESS));
+        assert(ds.getTimezone);
+        ds.getTimezone('-33.86,151.20', function(err, body, response) {
+          if (!checkGoogleMapAPIResult(err, response, done)) return;
+          var timeZoneId = body.timeZoneId;
+          assert.equal(timeZoneId.match(TEST_TIMEZONE).length, 1, 'Incorrect Time Zone ID');
+          var timeZone = body.timeZoneName;
+          assert.equal(timeZone.match(TEST_TIMEZONE).length, 1, 'Incorrect Time Zone Name');
+          done(err, body);
+        });
+      });
+    });
+
     it('should mix in invoke method', function(done) {
       var spec = {
         debug: false,

--- a/test/rest-adapter-custom.test.js
+++ b/test/rest-adapter-custom.test.js
@@ -187,7 +187,7 @@ describe('REST connector', function() {
       });
     });
 
-    it('should mix in custom path in all functions', function(done) {
+    it('should mix in predefined default values for all functions', function(done) {
       const TEST_ADDRESS = '107 S B St, San Mateo, CA 94401, USA';
       const TEST_TIMEZONE = /.*Australia.*/;
       var spec = {


### PR DESCRIPTION
### Description
When defining many paths through `datasources.json`, there may be a lot of overlapping `operations` just to handle simple variables that can be set as part of the function definition.

Allowing default values in the function definition can dramatically reduce the number of `operations` needed to be defined in the REST datasource. This allows easier to read and manage code. 

An example of the usage of this PR is seen here: 
```
"zosb": {
    "name": "zosb",
    "connector": "rest",
    ...
    "operations": [
      {
        "template": {
          "method": "GET",
          "url": "/ZosmfInstances/{!instanceId}/{path}",
          "options": {}
        },
        "functions": {
          "getZosmfInstance": ["instanceId"],
          "getZosmfInstanceScr": ["instanceId", "path=scr"],
          "getZosmfInstanceExists": ["instanceId", "path=exists"],
          "getZosmfInstancePath": ["instanceId", "path"]
        }
      }
    ]
  }
```

The code calling this modified REST datasource can now invoke all 4 of the above functions as so: 

```
const zosb = app.datasources.zosb;

let inst = await zosb.getZosmfInstance(id);
let instScr = await zosb.getZosmfInstanceScr(id);
let instExists = await zosb.getZosmfInstanceExists(id);
let instPath = await zosb.getZosmfInstancePath(id, 'someOtherPath');
      
console.log(inst);
console.log(instScr);
console.log(instExists);
console.log(instPath);
```

The non-promise versions of these callbacks will also work. All four responses are handled as expected and this removes the need from the client-side code needing to pass along a specific `path` value for paths that are static and can/should be set in the function template.

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
