### PR TITLE
test: use a local stub of Google Maps API

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha --timeout 30000 test/*test.js",
+    "test": "mocha",
     "posttest": "npm run lint"
   },
   "dependencies": {

--- a/test/fixtures/geocode-address-san_mateo_ca.json
+++ b/test/fixtures/geocode-address-san_mateo_ca.json
@@ -1,0 +1,104 @@
+{
+  "results": [
+    {
+      "address_components": [
+        {
+          "long_name": "107",
+          "short_name": "107",
+          "types": [
+            "street_number"
+          ]
+        },
+        {
+          "long_name": "South B Street",
+          "short_name": "S B St",
+          "types": [
+            "route"
+          ]
+        },
+        {
+          "long_name": "Downtown",
+          "short_name": "Downtown",
+          "types": [
+            "neighborhood",
+            "political"
+          ]
+        },
+        {
+          "long_name": "San Mateo",
+          "short_name": "San Mateo",
+          "types": [
+            "locality",
+            "political"
+          ]
+        },
+        {
+          "long_name": "San Mateo County",
+          "short_name": "San Mateo County",
+          "types": [
+            "administrative_area_level_2",
+            "political"
+          ]
+        },
+        {
+          "long_name": "California",
+          "short_name": "CA",
+          "types": [
+            "administrative_area_level_1",
+            "political"
+          ]
+        },
+        {
+          "long_name": "United States",
+          "short_name": "US",
+          "types": [
+            "country",
+            "political"
+          ]
+        },
+        {
+          "long_name": "94401",
+          "short_name": "94401",
+          "types": [
+            "postal_code"
+          ]
+        },
+        {
+          "long_name": "3993",
+          "short_name": "3993",
+          "types": [
+            "postal_code_suffix"
+          ]
+        }
+      ],
+      "formatted_address": "107 S B St, San Mateo, CA 94401, USA",
+      "geometry": {
+        "location": {
+          "lat": 37.5669986,
+          "lng": -122.3237495
+        },
+        "location_type": "ROOFTOP",
+        "viewport": {
+          "northeast": {
+            "lat": 37.56834758029149,
+            "lng": -122.3224005197085
+          },
+          "southwest": {
+            "lat": 37.56564961970849,
+            "lng": -122.3250984802915
+          }
+        }
+      },
+      "place_id": "ChIJX9EAz3Cej4ARJ3u8MO2Zdgc",
+      "plus_code": {
+        "compound_code": "HM8G+QG San Mateo, California, United States",
+        "global_code": "849VHM8G+QG"
+      },
+      "types": [
+        "street_address"
+      ]
+    }
+  ],
+  "status": "OK"
+}
+

--- a/test/fixtures/geocode-latlng-40.714224_-73.961452.json
+++ b/test/fixtures/geocode-latlng-40.714224_-73.961452.json
@@ -1,0 +1,846 @@
+{
+  "plus_code": {
+    "compound_code": "P27Q+MC New York, NY, USA",
+    "global_code": "87G8P27Q+MC"
+  },
+  "results": [
+    {
+      "address_components": [
+        {
+          "long_name": "279",
+          "short_name": "279",
+          "types": [
+            "street_number"
+          ]
+        },
+        {
+          "long_name": "Bedford Avenue",
+          "short_name": "Bedford Ave",
+          "types": [
+            "route"
+          ]
+        },
+        {
+          "long_name": "Williamsburg",
+          "short_name": "Williamsburg",
+          "types": [
+            "neighborhood",
+            "political"
+          ]
+        },
+        {
+          "long_name": "Brooklyn",
+          "short_name": "Brooklyn",
+          "types": [
+            "political",
+            "sublocality",
+            "sublocality_level_1"
+          ]
+        },
+        {
+          "long_name": "Kings County",
+          "short_name": "Kings County",
+          "types": [
+            "administrative_area_level_2",
+            "political"
+          ]
+        },
+        {
+          "long_name": "New York",
+          "short_name": "NY",
+          "types": [
+            "administrative_area_level_1",
+            "political"
+          ]
+        },
+        {
+          "long_name": "United States",
+          "short_name": "US",
+          "types": [
+            "country",
+            "political"
+          ]
+        },
+        {
+          "long_name": "11211",
+          "short_name": "11211",
+          "types": [
+            "postal_code"
+          ]
+        }
+      ],
+      "formatted_address": "279 Bedford Ave, Brooklyn, NY 11211, USA",
+      "geometry": {
+        "location": {
+          "lat": 40.7142484,
+          "lng": -73.9614103
+        },
+        "location_type": "ROOFTOP",
+        "viewport": {
+          "northeast": {
+            "lat": 40.71559738029149,
+            "lng": -73.9600613197085
+          },
+          "southwest": {
+            "lat": 40.71289941970849,
+            "lng": -73.96275928029151
+          }
+        }
+      },
+      "place_id": "ChIJT2x8Q2BZwokRpBu2jUzX3dE",
+      "plus_code": {
+        "compound_code": "P27Q+MC Brooklyn, New York, United States",
+        "global_code": "87G8P27Q+MC"
+      },
+      "types": [
+        "bakery",
+        "cafe",
+        "establishment",
+        "food",
+        "point_of_interest",
+        "store"
+      ]
+    },
+    {
+      "address_components": [
+        {
+          "long_name": "281",
+          "short_name": "281",
+          "types": [
+            "street_number"
+          ]
+        },
+        {
+          "long_name": "Bedford Avenue",
+          "short_name": "Bedford Ave",
+          "types": [
+            "route"
+          ]
+        },
+        {
+          "long_name": "Williamsburg",
+          "short_name": "Williamsburg",
+          "types": [
+            "neighborhood",
+            "political"
+          ]
+        },
+        {
+          "long_name": "Brooklyn",
+          "short_name": "Brooklyn",
+          "types": [
+            "political",
+            "sublocality",
+            "sublocality_level_1"
+          ]
+        },
+        {
+          "long_name": "Kings County",
+          "short_name": "Kings County",
+          "types": [
+            "administrative_area_level_2",
+            "political"
+          ]
+        },
+        {
+          "long_name": "New York",
+          "short_name": "NY",
+          "types": [
+            "administrative_area_level_1",
+            "political"
+          ]
+        },
+        {
+          "long_name": "United States",
+          "short_name": "US",
+          "types": [
+            "country",
+            "political"
+          ]
+        },
+        {
+          "long_name": "11211",
+          "short_name": "11211",
+          "types": [
+            "postal_code"
+          ]
+        },
+        {
+          "long_name": "4230",
+          "short_name": "4230",
+          "types": [
+            "postal_code_suffix"
+          ]
+        }
+      ],
+      "formatted_address": "281 Bedford Ave, Brooklyn, NY 11211, USA",
+      "geometry": {
+        "bounds": {
+          "northeast": {
+            "lat": 40.7142009,
+            "lng": -73.96120789999999
+          },
+          "southwest": {
+            "lat": 40.7140632,
+            "lng": -73.9614302
+          }
+        },
+        "location": {
+          "lat": 40.71412429999999,
+          "lng": -73.96130769999999
+        },
+        "location_type": "ROOFTOP",
+        "viewport": {
+          "northeast": {
+            "lat": 40.7154810302915,
+            "lng": -73.95997006970849
+          },
+          "southwest": {
+            "lat": 40.7127830697085,
+            "lng": -73.9626680302915
+          }
+        }
+      },
+      "place_id": "ChIJiYRKQWBZwokR10UtO7vMvr0",
+      "types": [
+        "premise"
+      ]
+    },
+    {
+      "address_components": [
+        {
+          "long_name": "277",
+          "short_name": "277",
+          "types": [
+            "street_number"
+          ]
+        },
+        {
+          "long_name": "Bedford Avenue",
+          "short_name": "Bedford Ave",
+          "types": [
+            "route"
+          ]
+        },
+        {
+          "long_name": "Williamsburg",
+          "short_name": "Williamsburg",
+          "types": [
+            "neighborhood",
+            "political"
+          ]
+        },
+        {
+          "long_name": "Brooklyn",
+          "short_name": "Brooklyn",
+          "types": [
+            "political",
+            "sublocality",
+            "sublocality_level_1"
+          ]
+        },
+        {
+          "long_name": "Kings County",
+          "short_name": "Kings County",
+          "types": [
+            "administrative_area_level_2",
+            "political"
+          ]
+        },
+        {
+          "long_name": "New York",
+          "short_name": "NY",
+          "types": [
+            "administrative_area_level_1",
+            "political"
+          ]
+        },
+        {
+          "long_name": "United States",
+          "short_name": "US",
+          "types": [
+            "country",
+            "political"
+          ]
+        },
+        {
+          "long_name": "11211",
+          "short_name": "11211",
+          "types": [
+            "postal_code"
+          ]
+        }
+      ],
+      "formatted_address": "277 Bedford Ave, Brooklyn, NY 11211, USA",
+      "geometry": {
+        "location": {
+          "lat": 40.7142205,
+          "lng": -73.9612903
+        },
+        "location_type": "ROOFTOP",
+        "viewport": {
+          "northeast": {
+            "lat": 40.71556948029149,
+            "lng": -73.95994131970849
+          },
+          "southwest": {
+            "lat": 40.7128715197085,
+            "lng": -73.9626392802915
+          }
+        }
+      },
+      "place_id": "ChIJd8BlQ2BZwokRAFUEcm_qrcA",
+      "plus_code": {
+        "compound_code": "P27Q+MF New York, United States",
+        "global_code": "87G8P27Q+MF"
+      },
+      "types": [
+        "street_address"
+      ]
+    },
+    {
+      "address_components": [
+        {
+          "long_name": "279",
+          "short_name": "279",
+          "types": [
+            "street_number"
+          ]
+        },
+        {
+          "long_name": "Bedford Avenue",
+          "short_name": "Bedford Ave",
+          "types": [
+            "route"
+          ]
+        },
+        {
+          "long_name": "Williamsburg",
+          "short_name": "Williamsburg",
+          "types": [
+            "neighborhood",
+            "political"
+          ]
+        },
+        {
+          "long_name": "Brooklyn",
+          "short_name": "Brooklyn",
+          "types": [
+            "political",
+            "sublocality",
+            "sublocality_level_1"
+          ]
+        },
+        {
+          "long_name": "Kings County",
+          "short_name": "Kings County",
+          "types": [
+            "administrative_area_level_2",
+            "political"
+          ]
+        },
+        {
+          "long_name": "New York",
+          "short_name": "NY",
+          "types": [
+            "administrative_area_level_1",
+            "political"
+          ]
+        },
+        {
+          "long_name": "United States",
+          "short_name": "US",
+          "types": [
+            "country",
+            "political"
+          ]
+        },
+        {
+          "long_name": "11211",
+          "short_name": "11211",
+          "types": [
+            "postal_code"
+          ]
+        }
+      ],
+      "formatted_address": "279 Bedford Ave, Brooklyn, NY 11211, USA",
+      "geometry": {
+        "location": {
+          "lat": 40.7142546,
+          "lng": -73.9614527
+        },
+        "location_type": "RANGE_INTERPOLATED",
+        "viewport": {
+          "northeast": {
+            "lat": 40.71560358029149,
+            "lng": -73.96010371970848
+          },
+          "southwest": {
+            "lat": 40.71290561970849,
+            "lng": -73.9628016802915
+          }
+        }
+      },
+      "place_id": "EigyNzkgQmVkZm9yZCBBdmUsIEJyb29rbHluLCBOWSAxMTIxMSwgVVNBIhsSGQoUChIJ8ThWRGBZwokR3E1zUisk3LUQlwI",
+      "types": [
+        "street_address"
+      ]
+    },
+    {
+      "address_components": [
+        {
+          "long_name": "11211",
+          "short_name": "11211",
+          "types": [
+            "postal_code"
+          ]
+        },
+        {
+          "long_name": "Brooklyn",
+          "short_name": "Brooklyn",
+          "types": [
+            "political",
+            "sublocality",
+            "sublocality_level_1"
+          ]
+        },
+        {
+          "long_name": "New York",
+          "short_name": "New York",
+          "types": [
+            "locality",
+            "political"
+          ]
+        },
+        {
+          "long_name": "New York",
+          "short_name": "NY",
+          "types": [
+            "administrative_area_level_1",
+            "political"
+          ]
+        },
+        {
+          "long_name": "United States",
+          "short_name": "US",
+          "types": [
+            "country",
+            "political"
+          ]
+        }
+      ],
+      "formatted_address": "Brooklyn, NY 11211, USA",
+      "geometry": {
+        "bounds": {
+          "northeast": {
+            "lat": 40.7280089,
+            "lng": -73.9207299
+          },
+          "southwest": {
+            "lat": 40.7008331,
+            "lng": -73.9644697
+          }
+        },
+        "location": {
+          "lat": 40.7093358,
+          "lng": -73.9565551
+        },
+        "location_type": "APPROXIMATE",
+        "viewport": {
+          "northeast": {
+            "lat": 40.7280089,
+            "lng": -73.9207299
+          },
+          "southwest": {
+            "lat": 40.7008331,
+            "lng": -73.9644697
+          }
+        }
+      },
+      "place_id": "ChIJvbEjlVdZwokR4KapM3WCFRw",
+      "types": [
+        "postal_code"
+      ]
+    },
+    {
+      "address_components": [
+        {
+          "long_name": "Williamsburg",
+          "short_name": "Williamsburg",
+          "types": [
+            "neighborhood",
+            "political"
+          ]
+        },
+        {
+          "long_name": "Brooklyn",
+          "short_name": "Brooklyn",
+          "types": [
+            "political",
+            "sublocality",
+            "sublocality_level_1"
+          ]
+        },
+        {
+          "long_name": "Kings County",
+          "short_name": "Kings County",
+          "types": [
+            "administrative_area_level_2",
+            "political"
+          ]
+        },
+        {
+          "long_name": "New York",
+          "short_name": "NY",
+          "types": [
+            "administrative_area_level_1",
+            "political"
+          ]
+        },
+        {
+          "long_name": "United States",
+          "short_name": "US",
+          "types": [
+            "country",
+            "political"
+          ]
+        }
+      ],
+      "formatted_address": "Williamsburg, Brooklyn, NY, USA",
+      "geometry": {
+        "bounds": {
+          "northeast": {
+            "lat": 40.7251773,
+            "lng": -73.936498
+          },
+          "southwest": {
+            "lat": 40.6979329,
+            "lng": -73.96984499999999
+          }
+        },
+        "location": {
+          "lat": 40.7081156,
+          "lng": -73.9570696
+        },
+        "location_type": "APPROXIMATE",
+        "viewport": {
+          "northeast": {
+            "lat": 40.7251773,
+            "lng": -73.936498
+          },
+          "southwest": {
+            "lat": 40.6979329,
+            "lng": -73.96984499999999
+          }
+        }
+      },
+      "place_id": "ChIJQSrBBv1bwokRbNfFHCnyeYI",
+      "types": [
+        "neighborhood",
+        "political"
+      ]
+    },
+    {
+      "address_components": [
+        {
+          "long_name": "Brooklyn",
+          "short_name": "Brooklyn",
+          "types": [
+            "political",
+            "sublocality",
+            "sublocality_level_1"
+          ]
+        },
+        {
+          "long_name": "Kings County",
+          "short_name": "Kings County",
+          "types": [
+            "administrative_area_level_2",
+            "political"
+          ]
+        },
+        {
+          "long_name": "New York",
+          "short_name": "NY",
+          "types": [
+            "administrative_area_level_1",
+            "political"
+          ]
+        },
+        {
+          "long_name": "United States",
+          "short_name": "US",
+          "types": [
+            "country",
+            "political"
+          ]
+        }
+      ],
+      "formatted_address": "Brooklyn, NY, USA",
+      "geometry": {
+        "bounds": {
+          "northeast": {
+            "lat": 40.739446,
+            "lng": -73.8333651
+          },
+          "southwest": {
+            "lat": 40.551042,
+            "lng": -74.05663
+          }
+        },
+        "location": {
+          "lat": 40.6781784,
+          "lng": -73.9441579
+        },
+        "location_type": "APPROXIMATE",
+        "viewport": {
+          "northeast": {
+            "lat": 40.739446,
+            "lng": -73.8333651
+          },
+          "southwest": {
+            "lat": 40.551042,
+            "lng": -74.05663
+          }
+        }
+      },
+      "place_id": "ChIJCSF8lBZEwokRhngABHRcdoI",
+      "types": [
+        "political",
+        "sublocality",
+        "sublocality_level_1"
+      ]
+    },
+    {
+      "address_components": [
+        {
+          "long_name": "Kings County",
+          "short_name": "Kings County",
+          "types": [
+            "administrative_area_level_2",
+            "political"
+          ]
+        },
+        {
+          "long_name": "Brooklyn",
+          "short_name": "Brooklyn",
+          "types": [
+            "political",
+            "sublocality",
+            "sublocality_level_1"
+          ]
+        },
+        {
+          "long_name": "New York",
+          "short_name": "NY",
+          "types": [
+            "administrative_area_level_1",
+            "political"
+          ]
+        },
+        {
+          "long_name": "United States",
+          "short_name": "US",
+          "types": [
+            "country",
+            "political"
+          ]
+        }
+      ],
+      "formatted_address": "Kings County, Brooklyn, NY, USA",
+      "geometry": {
+        "bounds": {
+          "northeast": {
+            "lat": 40.739446,
+            "lng": -73.8333651
+          },
+          "southwest": {
+            "lat": 40.551042,
+            "lng": -74.05663
+          }
+        },
+        "location": {
+          "lat": 40.6528762,
+          "lng": -73.95949399999999
+        },
+        "location_type": "APPROXIMATE",
+        "viewport": {
+          "northeast": {
+            "lat": 40.739446,
+            "lng": -73.8333651
+          },
+          "southwest": {
+            "lat": 40.551042,
+            "lng": -74.05663
+          }
+        }
+      },
+      "place_id": "ChIJOwE7_GTtwokRs75rhW4_I6M",
+      "types": [
+        "administrative_area_level_2",
+        "political"
+      ]
+    },
+    {
+      "address_components": [
+        {
+          "long_name": "New York",
+          "short_name": "New York",
+          "types": [
+            "locality",
+            "political"
+          ]
+        },
+        {
+          "long_name": "New York",
+          "short_name": "NY",
+          "types": [
+            "administrative_area_level_1",
+            "political"
+          ]
+        },
+        {
+          "long_name": "United States",
+          "short_name": "US",
+          "types": [
+            "country",
+            "political"
+          ]
+        }
+      ],
+      "formatted_address": "New York, NY, USA",
+      "geometry": {
+        "bounds": {
+          "northeast": {
+            "lat": 40.9175771,
+            "lng": -73.70027209999999
+          },
+          "southwest": {
+            "lat": 40.4773991,
+            "lng": -74.25908989999999
+          }
+        },
+        "location": {
+          "lat": 40.7127753,
+          "lng": -74.0059728
+        },
+        "location_type": "APPROXIMATE",
+        "viewport": {
+          "northeast": {
+            "lat": 40.9175771,
+            "lng": -73.70027209999999
+          },
+          "southwest": {
+            "lat": 40.4773991,
+            "lng": -74.25908989999999
+          }
+        }
+      },
+      "place_id": "ChIJOwg_06VPwokRYv534QaPC8g",
+      "types": [
+        "locality",
+        "political"
+      ]
+    },
+    {
+      "address_components": [
+        {
+          "long_name": "New York",
+          "short_name": "NY",
+          "types": [
+            "administrative_area_level_1",
+            "political"
+          ]
+        },
+        {
+          "long_name": "United States",
+          "short_name": "US",
+          "types": [
+            "country",
+            "political"
+          ]
+        }
+      ],
+      "formatted_address": "New York, USA",
+      "geometry": {
+        "bounds": {
+          "northeast": {
+            "lat": 45.015865,
+            "lng": -71.777491
+          },
+          "southwest": {
+            "lat": 40.4773991,
+            "lng": -79.7625901
+          }
+        },
+        "location": {
+          "lat": 43.2994285,
+          "lng": -74.21793260000001
+        },
+        "location_type": "APPROXIMATE",
+        "viewport": {
+          "northeast": {
+            "lat": 45.015865,
+            "lng": -71.777491
+          },
+          "southwest": {
+            "lat": 40.4773991,
+            "lng": -79.7625901
+          }
+        }
+      },
+      "place_id": "ChIJqaUj8fBLzEwRZ5UY3sHGz90",
+      "types": [
+        "administrative_area_level_1",
+        "political"
+      ]
+    },
+    {
+      "address_components": [
+        {
+          "long_name": "United States",
+          "short_name": "US",
+          "types": [
+            "country",
+            "political"
+          ]
+        }
+      ],
+      "formatted_address": "United States",
+      "geometry": {
+        "bounds": {
+          "northeast": {
+            "lat": 71.5388001,
+            "lng": -66.885417
+          },
+          "southwest": {
+            "lat": 18.7763,
+            "lng": 170.5957
+          }
+        },
+        "location": {
+          "lat": 37.09024,
+          "lng": -95.712891
+        },
+        "location_type": "APPROXIMATE",
+        "viewport": {
+          "northeast": {
+            "lat": 71.5388001,
+            "lng": -66.885417
+          },
+          "southwest": {
+            "lat": 18.7763,
+            "lng": 170.5957
+          }
+        }
+      },
+      "place_id": "ChIJCzYy5IS16lQRQrfeQ5K5Oxw",
+      "types": [
+        "country",
+        "political"
+      ]
+    }
+  ],
+  "status": "OK"
+}
+

--- a/test/fixtures/geocoder-stub.js
+++ b/test/fixtures/geocoder-stub.js
@@ -1,0 +1,55 @@
+// Copyright IBM Corp. 2013,2016. All Rights Reserved.
+// Node module: loopback-connector-rest
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const assert = require('assert');
+const express = require('express');
+const should = require('should');
+
+const router = express.Router();
+module.exports = router;
+
+router.use((req, res, next) => {
+  should(req.headers).containEql({
+    accept: 'application/json',
+    'content-type': 'application/json',
+  });
+  next();
+});
+
+router.get('/maps/api/geocode/json', function geocode(req, res, next) {
+  if (req.query.latlng === '40.714224,-73.961452') {
+    // response for the following GET request:
+    // https://maps.googleapis.com/maps/api/geocode/json?key={key}&latlng=40.714224,-73.961452
+    res.json(require('./geocode-latlng-40.714224_-73.961452.json'));
+  } else if (req.query.address === '107 S B St, San Mateo, CA') {
+    // response for the following GET request:
+    // https://maps.googleapis.com/maps/api/geocode/json?key={key}&address=107 S B St, San Mateo, CA
+    res.json(require('./geocode-address-san_mateo_ca.json'));
+  } else {
+    throw new Error('Invalid geocode request: ', req.query);
+  }
+});
+
+router.get('/maps/api/timezone/json', function timezone(req, res, next) {
+  if (req.query.location === '-33.86,151.20') {
+    // response for the following GET request:
+    // https://maps.googleapis.com/maps/api/timezone/json?key={key}&location=-33.86,151.20
+    res.json(require('./timezone-location--33.86_151.20.json'));
+  } else {
+    throw new Error('Invalid timezone request: ', req.query);
+  }
+});
+
+router.use(function reportErrorsToMocha(err, req, res, next) {
+  // escape Express error handler
+  process.nextTick(() => {
+    // always end the response
+    process.nextTick(() => res.end());
+    // throw the error so that Mocha can fail the test
+    throw err;
+  });
+});

--- a/test/fixtures/timezone-location--33.86_151.20.json
+++ b/test/fixtures/timezone-location--33.86_151.20.json
@@ -1,0 +1,7 @@
+{
+  "dstOffset":3600,
+  "rawOffset":36000,
+  "status":"OK",
+  "timeZoneId":"Australia/Sydney",
+  "timeZoneName":"Australian Eastern Daylight Time"
+}


### PR DESCRIPTION
Google Maps API no longer allow anonymous usage. As a result, our tests calling Maps API started to fail.

This pull request reworks our test suite to use a locally running stub server instead of calling external service.

As a nice side effect, our test suite runs much faster now 🏎 

#### Related issues

Resolves #133 

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
