### PR TITLE
[Fix] Updated index on template build and fixed test

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -146,6 +146,9 @@ JsonTemplate.prototype.build = function(parameters) {
             required = true;
           }
           var val = parameters[name]; // Name is param[1]
+          // Update the index to the first of the match
+          index = match.index;
+          // Continue if the object variable is not defined in template
           if (self.schema[name] === undefined) continue;
           var type = self.schema[name].type;
           if (typeof type === 'function') {

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -139,9 +139,12 @@ describe('JsonTemplate', function() {
         });
 
         var bodyContent = {id: 1, template: 'this is a normal content with ${var} variables'};
+        // deep clone bodyContent, as template.build will mutate it
+        var cloned = JSON.parse(JSON.stringify(bodyContent));
 
         var result = template.build({body: bodyContent});
-        assert.equal(bodyContent, result.body);
+        assert.equal(cloned.id, result.body.id);
+        assert.equal(cloned.template, result.body.template);
         done(null, result);
       });
 


### PR DESCRIPTION
### Description

Loopback-connector-rest should support object variables with expressions {var} when is not defined in template (as mentioned in the test). However, it was not working correctly.

Due to the test was written in the following way
```
assert.equal(bodyContent, result.body);
```
where `build` function will mutate the original values, hence, the test wasn't working correctly.

When added logging, you can see:
![image](https://user-images.githubusercontent.com/26216852/65472365-1c2e8f80-deae-11e9-851b-2dcefe7a9c56.png)

#### Related issues

- connect to https://github.com/strongloop/loopback-connector-rest/issues/141

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
