### PR TITLE
chore: update copyrights year

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2018. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-connector-rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/lib/experimental/json-schema-discovery.js
+++ b/lib/experimental/json-schema-discovery.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2018. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-connector-rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/lib/experimental/rest-swagger.js
+++ b/lib/experimental/rest-swagger.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2018. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-connector-rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/lib/rest-builder.js
+++ b/lib/rest-builder.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2018. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-connector-rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/lib/rest-connector.js
+++ b/lib/rest-connector.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2018. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-connector-rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/lib/rest-model.js
+++ b/lib/rest-model.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2018. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-connector-rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/lib/template.js
+++ b/lib/template.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2018. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-connector-rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2018. All Rights Reserved.
+// Copyright IBM Corp. 2015,2019. All Rights Reserved.
 // Node module: loopback-connector-rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/express-helper.js
+++ b/test/express-helper.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014,2018. All Rights Reserved.
+// Copyright IBM Corp. 2014,2019. All Rights Reserved.
 // Node module: loopback-connector-rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/rest-builder.test.js
+++ b/test/rest-builder.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2018. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-connector-rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/rest-loopback.test.js
+++ b/test/rest-loopback.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2018. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-connector-rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/rest-model.test.js
+++ b/test/rest-model.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2018. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-connector-rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2018. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-connector-rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Related: strongloop-internal/scrum-apex#440

Update the copyrights year in the rest of the packages besides #4596.

The changes are introduced by running the `slt copyright` command. I'm skipping the fixtures folders.


## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-rest) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
