### PR TITLE
feat: Implement a flag to return the full response instead of body

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ The `template` object specifies the REST API invocation as a JSON template, with
 | `headers`| HTTP headers | Object |
 | `query`| Query strings | Object; template values allowed. |
 | `responsePath`| Optional JSONPath applied to the HTTP body. See [https://github.com/s3u/JSONPath](https://github.com/s3u/JSONPath) for syntax of JSON paths.| String |
+| `fullResponse`| Optional flag to return full response, rather than just body. | Boolean |
 
 The template variable syntax is:
 

--- a/lib/rest-builder.js
+++ b/lib/rest-builder.js
@@ -339,6 +339,16 @@ RequestBuilder.prototype.responsePath = function(responsePath) {
 };
 
 /**
+ * Set the response json path
+ * @param {string} fullResponse The JSONPath to be applied against the HTTP body
+ * @returns {RequestBuilder}
+ */
+RequestBuilder.prototype.fullResponse = function(fullResponse) {
+  this.template.template.fullResponse = fullResponse;
+  return this;
+};
+
+/**
  * Define the parser to be used for this response.
  *
  * @param {function} fn The parser function
@@ -554,6 +564,9 @@ RequestBuilder.prototype.invoke = function(parameters, cb) {
             json: body,
             path: self.template.template.responsePath,
           });
+        }
+        if (self.template.template.fullResponse) {
+          result = response;
         }
         if (debug.enabled) {
           debug('Response: %j', result);

--- a/lib/rest-builder.js
+++ b/lib/rest-builder.js
@@ -339,8 +339,8 @@ RequestBuilder.prototype.responsePath = function(responsePath) {
 };
 
 /**
- * Set the response json path
- * @param {string} fullResponse The JSONPath to be applied against the HTTP body
+ * Set the fullResponse flag
+ * @param {string} fullResponse flag to return full response, rather than just body
  * @returns {RequestBuilder}
  */
 RequestBuilder.prototype.fullResponse = function(fullResponse) {

--- a/test/rest-builder.test.js
+++ b/test/rest-builder.test.js
@@ -297,4 +297,59 @@ describe('REST Request Builder', function() {
         });
     });
   });
+
+  describe('supplying fullResponse flag', function() {
+    var hostURL = 'http://localhost:';
+    var server = null;
+
+    before(function(done) {
+      var app = require('./express-helper')();
+
+      app.all('*', function(req, res, next) {
+        res.setHeader('Content-Type', 'application/json');
+        var payload = {
+          exampleParamater: 'testing',
+        };
+        res.status(200).json(payload);
+      });
+
+      server = app.listen(app.get('port'), function(err, data) {
+        // console.log('Server listening on ', server.address().port);
+        hostURL += server.address().port;
+        done(err, data);
+      });
+    });
+
+    after(function(done) {
+      if (server) server.close(done);
+    });
+
+    it('should return full response', function(done) {
+      var builder = new RequestBuilder({method: 'GET', url: hostURL, fullResponse: true});
+      builder
+        .invoke()
+        .then(function(response) {
+          assert(typeof response.body == 'object');
+          assert(typeof response.body.exampleParamater == 'string');
+          assert(typeof response.headers == 'object');
+          done();
+        })
+        .catch(function(err) {
+          assert.fail();
+        });
+    });
+    it('should return body only', function(done) {
+      var builder = new RequestBuilder({method: 'POST', url: hostURL, fullResponse: false});
+      builder
+        .invoke()
+        .then(function(response) {
+          assert(typeof response == 'object');
+          assert(typeof response.exampleParamater == 'string');
+          done();
+        })
+        .catch(function(err) {
+          assert.fail();
+        });
+    });
+  });
 });


### PR DESCRIPTION
This PR is to enable a new flag for returning the full response rather than just the body. 

See also #131 where I think this was attempted before but has gone stale and closed. 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-rest) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
